### PR TITLE
Added JrVulkanContext to improve development efficiency of JrObjects

### DIFF
--- a/imgui.ini
+++ b/imgui.ini
@@ -4,15 +4,15 @@ Size=400,400
 Collapsed=0
 
 [Window][window]
-ViewportPos=472,325
+ViewportPos=406,378
 ViewportId=0x7FDABC89
-Size=468,377
+Size=470,479
 Collapsed=0
 
 [Window][Dear ImGui Demo]
-ViewportPos=1552,245
+ViewportPos=1084,341
 ViewportId=0x59819E39
-Size=550,680
+Size=721,437
 Collapsed=0
 
 [Docking][Data]

--- a/include/JanRenderer/JanRenderer.hpp
+++ b/include/JanRenderer/JanRenderer.hpp
@@ -6,17 +6,17 @@
 
 #include "common.hpp"
 
-struct QueueFamily {
-  std::optional<uint32_t> graphicsFamily;
-  std::optional<uint32_t> presentFamily;
-  std::optional<uint32_t> transferFamily;
-  std::optional<uint32_t> computeFamily;
+// struct QueueFamilyIndices {
+//   std::optional<uint32_t> graphicsFamily;
+//   std::optional<uint32_t> presentFamily;
+//   std::optional<uint32_t> transferFamily;
+//   std::optional<uint32_t> computeFamily;
 
-  bool isComplete() {
-    return graphicsFamily.has_value() && presentFamily.has_value() &&
-           transferFamily.has_value() && computeFamily.has_value();
-  }
-};
+//  bool isComplete() {
+//    return graphicsFamily.has_value() && presentFamily.has_value() &&
+//           transferFamily.has_value() && computeFamily.has_value();
+//  }
+//};
 
 struct SwapChainSupportDetails {
   VkSurfaceCapabilitiesKHR capabilities;
@@ -162,7 +162,7 @@ private:
   VkDevice device;
 
   // queue
-  QueueFamily queueFamily;
+  JrQueueFamilyIndices queueFamilyIndices;
   VkQueue graphicsQueue;
   VkQueue presentQueue;
   VkQueue transferQueue;
@@ -240,6 +240,7 @@ private:
   std::vector<VkDeviceMemory> shaderStorageBuffersMemory;
 
   // HMODULE JrClasses_lib; dynamic loading of JrClasses library (old way)
+  JrVulkanContext *vulkanCtx;
   JrCamera *camera;
   JrGui *gui;
 
@@ -267,7 +268,7 @@ private:
 
     return VK_FALSE;
   }
-  QueueFamily getQueueFamily(VkPhysicalDevice physicalDevice_);
+  JrQueueFamilyIndices getQueueFamilyIndices(VkPhysicalDevice physicalDevice_);
   uint32_t findMemoryType(uint32_t typeFilter,
                           VkMemoryPropertyFlags properties);
   void createBuffer(VkDeviceSize size, VkBufferUsageFlags usage,
@@ -369,7 +370,8 @@ private:
 
   void createSyncObjects();
 
-  // initGui
+  // initJrObjectsAfterInitVulkan
+  void initJrObjectsAfterInitVulkan();
   void initGui();
 
   // mainLoop

--- a/include/JanRenderer/JrObjects.hpp
+++ b/include/JanRenderer/JrObjects.hpp
@@ -3,6 +3,35 @@
 #include <JanRenderer/common.hpp>
 
 extern "C" {
+struct JrQueueFamilyIndices {
+  uint32_t graphicsFamily;
+  uint32_t presentFamily;
+  uint32_t transferFamily;
+  uint32_t computeFamily;
+};
+bool jrQueueFamilyIndices_isComplete(JrQueueFamilyIndices *);
+
+struct JrVulkanContext {
+  VkInstance *instance;
+
+  VkPhysicalDevice *physicalDevice;
+  VkDevice *device;
+
+  JrQueueFamilyIndices *queueFamilyIndices;
+  VkQueue *graphicsQueue;
+  VkQueue *presentQueue;
+  VkQueue *transferQueue;
+  VkQueue *computeQueue;
+
+  VkSwapchainKHR *swapChain;
+  VkImage *swapChainImages;
+  VkFormat *swapChainFormat;
+  VkExtent2D *swapChainExtent;
+  VkImageView *swapChainImageViews;
+
+  VkRenderPass *renderPass;
+};
+
 struct JrCamera {
   vec3s position;
   vec3s velocity;
@@ -51,20 +80,15 @@ struct JrGuiViewModel {
 };
 
 struct JrGui {
-  VkDevice device;
-  uint32_t queueFamilyIndex;
-  VkQueue queue;
-  VkFormat swapChainImageFormat;
-  VkExtent2D swapChainExtent;
-  VkImageView *swapChainImageViews;
+  JrVulkanContext *vulkanCtx;
   VkFramebuffer swapChainFramebuffers[3];
   VkRenderPass renderPass;
   VkCommandPool commandPool;
   VkCommandBuffer commandBuffers[3];
   VkSemaphore renderFinishedSemaphores[3];
   VkDescriptorPool descriptorPool;
-  uint32_t currentFrame;
   VkSampleCountFlagBits msaaSamples;
+  uint32_t currentFrame;
   GLFWwindow *window;
   ImGui_ImplVulkan_InitInfo initInfo;
   void *fontSet;

--- a/src/JanRenderer/JrObjects/JrCamera.zig
+++ b/src/JanRenderer/JrObjects/JrCamera.zig
@@ -68,7 +68,7 @@ pub export fn jrCamera_getProjectionMatrix(self: *JrCamera, aspectRatio: f32) ca
 pub export fn jrCamera_keyCallback(window: *zglfw.Window, key: zglfw.Key, scancode: c_int, action: zglfw.Action, mods: zglfw.Mods) callconv(.C) void {
     _ = scancode;
     _ = mods;
-    const self = zglfw.getWindowUserPointer(window, common.GlfwUserPointer).?.camera orelse @panic("Problem with key callback");
+    const self = zglfw.getWindowUserPointer(window, common.JrGlfwUserPointer).?.camera orelse @panic("Problem with key callback");
 
     if (action == zglfw.Action.press) {
         if (key == zglfw.Key.w) {
@@ -106,7 +106,7 @@ pub export fn jrCamera_keyCallback(window: *zglfw.Window, key: zglfw.Key, scanco
 //}
 
 pub export fn jrCamera_cursorPositionCallback(window: *zglfw.Window, xpos: f64, ypos: f64) callconv(.C) void {
-    const self = zglfw.getWindowUserPointer(window, common.GlfwUserPointer).?.camera orelse @panic("Problem with cursor position callback");
+    const self = zglfw.getWindowUserPointer(window, common.JrGlfwUserPointer).?.camera orelse @panic("Problem with cursor position callback");
     const static = struct {
         var firstMouse: bool = true;
         var lastXpos: f64 = 0;
@@ -138,7 +138,7 @@ pub export fn jrCamera_cursorPositionCallback(window: *zglfw.Window, xpos: f64, 
 
 pub export fn jrCamera_mouseButtonCallback(window: *zglfw.Window, button: zglfw.MouseButton, action: zglfw.Action, mods: zglfw.Mods) callconv(.C) void {
     _ = mods;
-    const self = zglfw.getWindowUserPointer(window, common.GlfwUserPointer).?.camera orelse @panic("Problem with mouse button callback");
+    const self = zglfw.getWindowUserPointer(window, common.JrGlfwUserPointer).?.camera orelse @panic("Problem with mouse button callback");
 
     if (button == zglfw.MouseButton.right) {
         if (action == zglfw.Action.press) {
@@ -151,7 +151,7 @@ pub export fn jrCamera_mouseButtonCallback(window: *zglfw.Window, button: zglfw.
 
 pub export fn jrCamera_scrollCallback(window: *zglfw.Window, xoffset: f64, yoffset: f64) callconv(.C) void {
     _ = xoffset;
-    const self = zglfw.getWindowUserPointer(window, common.GlfwUserPointer).?.camera orelse @panic("Problem with scroll callback");
+    const self = zglfw.getWindowUserPointer(window, common.JrGlfwUserPointer).?.camera orelse @panic("Problem with scroll callback");
     self.fieldOfView -= @floatCast(yoffset);
 
     //if (self.fieldOfView < 1) self.fieldOfView = 1;

--- a/src/JanRenderer/JrObjects/JrQueueFamilyIndices.zig
+++ b/src/JanRenderer/JrObjects/JrQueueFamilyIndices.zig
@@ -1,0 +1,19 @@
+const std = @import("std");
+const volk = @cImport({
+    @cInclude("volk.h");
+});
+const cglm = @cImport({
+    @cDefine("CGLM_FORCE_DEPTH_ZERO_TO_ONE", "");
+    @cInclude("cglm/struct.h");
+});
+
+const Self = @This();
+
+graphics_family: ?u32,
+present_family: ?u32,
+transfer_family: ?u32,
+compute_family: ?u32,
+
+pub export fn jrQueueFamilyIndices_isComplete(self: *Self) callconv(.C) bool {
+    return self.graphics_family != null and self.present_family != null and self.transfer_family != null and self.compute_family != null;
+}

--- a/src/JanRenderer/JrObjects/JrVulkanContext.zig
+++ b/src/JanRenderer/JrObjects/JrVulkanContext.zig
@@ -1,0 +1,30 @@
+const std = @import("std");
+const volk = @cImport({
+    @cInclude("volk.h");
+});
+const cglm = @cImport({
+    @cDefine("CGLM_FORCE_DEPTH_ZERO_TO_ONE", "");
+    @cInclude("cglm/struct.h");
+});
+const JrQueueFamilyIndices = @import("JrQueueFamilyIndices.zig");
+
+const Self = @This();
+
+instance: *volk.VkInstance,
+
+physicalDevice: *volk.VkPhysicalDevice,
+device: *volk.VkDevice,
+
+queueFamilyIndices: *JrQueueFamilyIndices,
+graphics_queue: *volk.VkQueue,
+present_queue: *volk.VkQueue,
+transfer_queue: *volk.VkQueue,
+compute_queue: *volk.VkQueue,
+
+swapchain: *volk.VkSwapchainKHR,
+swapchain_images: *[3]volk.VkImage,
+swapchain_format: *volk.VkFormat,
+swapchain_extent: *volk.VkExtent2D,
+swapchain_imageViews: *[3]volk.VkImageView,
+
+renderPass: *volk.VkRenderPass,

--- a/src/JanRenderer/JrObjects/common.zig
+++ b/src/JanRenderer/JrObjects/common.zig
@@ -1,18 +1,16 @@
 const std = @import("std");
+const volk = @cImport({
+    @cInclude("volk.h");
+});
 const cglm = @cImport({
     @cDefine("CGLM_FORCE_DEPTH_ZERO_TO_ONE", "");
     @cInclude("cglm/struct.h");
-});
-const glfw = @cImport({
-    @cDefine("VK_USE_PLATFORM_WIN32_KHR", "");
-    @cDefine("GLFW_INCLUDE_VULKAN", "");
-    @cInclude("GLFW/glfw3.h");
 });
 
 pub const JrCamera = @import("JrCamera.zig");
 pub const JrShader = @import("JrShader.zig");
 
-pub const GlfwUserPointer = extern struct {
+pub const JrGlfwUserPointer = extern struct {
     camera: ?*JrCamera.JrCamera,
     renderer: ?*anyopaque,
 };


### PR DESCRIPTION
1. Now the member variables of the main renderer object (VkInstance, VkDevice, etc.) can be accessed from JrObjects.
2. Moved definition of JrCamera's initInfo to the initialization function (jrGui_init).
3. Refactored QueueFamilyIndices to JrQueueFamilyIndices.